### PR TITLE
Implement getRoomState query for real-time room state management

### DIFF
--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -172,3 +172,285 @@ export const joinRoom = mutation({
     return { roomId: room._id, success: true };
   },
 });
+
+// Get room state (real-time subscription)
+export const getRoomState = query({
+  args: {
+    roomId: v.id("rooms"),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      room: v.object({
+        _id: v.id("rooms"),
+        code: v.string(),
+        name: v.string(),
+        status: v.string(),
+        settings: v.object({
+          maxPlayers: v.float64(),
+          roundsPerGame: v.float64(),
+          timePerRound: v.float64(),
+          isPrivate: v.boolean(),
+          allowLateJoin: v.boolean(),
+        }),
+        currentRound: v.optional(v.float64()),
+      }),
+      players: v.array(v.object({
+        _id: v.id("players"),
+        userId: v.id("users"),
+        username: v.string(),
+        displayName: v.string(),
+        status: v.string(),
+        isHost: v.boolean(),
+        score: v.float64(),
+      })),
+      isHost: v.boolean(),
+      canStart: v.boolean(),
+    })
+  ),
+  handler: async (ctx, args) => {
+    const room = await ctx.db.get(args.roomId);
+    if (!room) return null;
+    
+    const userId = await getAuthUserId(ctx);
+    const currentUser = userId ? await ctx.db.get(userId) : null;
+    
+    // Get all players with user info (excluding kicked players)
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
+      .filter((q) => q.neq(q.field("status"), "kicked"))
+      .collect();
+      
+    const playersWithInfo = await Promise.all(
+      players.map(async (player) => {
+        const user = await ctx.db.get(player.userId);
+        return {
+          _id: player._id,
+          userId: player.userId,
+          username: user?.username ?? "Guest",
+          displayName: user?.displayName ?? user?.username ?? "Guest",
+          status: player.status,
+          isHost: player.isHost,
+          score: player.score,
+        };
+      })
+    );
+    
+    const connectedPlayers = playersWithInfo.filter(p => p.status === "connected");
+    
+    return {
+      room: {
+        _id: room._id,
+        code: room.code,
+        name: room.name,
+        status: room.status,
+        settings: room.settings,
+        currentRound: room.currentRound,
+      },
+      players: playersWithInfo,
+      isHost: currentUser?._id === room.hostId,
+      canStart: room.status === "waiting" && connectedPlayers.length >= 2,
+    };
+  },
+});
+
+// Leave a room
+export const leaveRoom = mutation({
+  args: {
+    roomId: v.id("rooms"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("User not found");
+    
+    const room = await ctx.db.get(args.roomId);
+    if (!room) throw new Error("Room not found");
+    
+    const player = await ctx.db
+      .query("players")
+      .withIndex("by_room_and_user", (q) =>
+        q.eq("roomId", args.roomId).eq("userId", user._id)
+      )
+      .unique();
+      
+    if (!player) throw new Error("Not in this room");
+    
+    // If host is leaving and game hasn't started, transfer host or close room
+    if (player.isHost && room.status === "waiting") {
+      const otherPlayers = await ctx.db
+        .query("players")
+        .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
+        .filter((q) => 
+          q.and(
+            q.neq(q.field("userId"), user._id),
+            q.eq(q.field("status"), "connected")
+          )
+        )
+        .collect();
+      
+      if (otherPlayers.length > 0) {
+        // Transfer host to next player
+        await ctx.db.patch(otherPlayers[0]._id, { isHost: true });
+        await ctx.db.patch(room._id, { hostId: otherPlayers[0].userId });
+      } else {
+        // Close room if no other players
+        await ctx.db.patch(room._id, { status: "finished", finishedAt: Date.now() });
+      }
+    }
+    
+    // Remove or disconnect player
+    if (room.status === "waiting") {
+      await ctx.db.delete(player._id);
+    } else {
+      await ctx.db.patch(player._id, { status: "disconnected" });
+    }
+    
+    return null;
+  },
+});
+
+// Kick a player (host only)
+export const kickPlayer = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    playerId: v.id("players"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    
+    const room = await ctx.db.get(args.roomId);
+    if (!room) throw new Error("Room not found");
+    
+    const user = await ctx.db.get(userId);
+    if (!user || user._id !== room.hostId) {
+      throw new Error("Only the host can kick players");
+    }
+    
+    const targetPlayer = await ctx.db.get(args.playerId);
+    if (!targetPlayer) throw new Error("Player not found");
+    
+    if (targetPlayer.isHost) {
+      throw new Error("Cannot kick the host");
+    }
+    
+    await ctx.db.patch(args.playerId, {
+      status: "kicked",
+    });
+    
+    return null;
+  },
+});
+
+// Update room settings (host only)
+export const updateRoomSettings = mutation({
+  args: {
+    roomId: v.id("rooms"),
+    settings: v.object({
+      maxPlayers: v.optional(v.float64()),
+      roundsPerGame: v.optional(v.float64()),
+      timePerRound: v.optional(v.float64()),
+      isPrivate: v.optional(v.boolean()),
+    }),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    
+    const room = await ctx.db.get(args.roomId);
+    if (!room) throw new Error("Room not found");
+    
+    if (room.status !== "waiting") {
+      throw new Error("Cannot change settings after game starts");
+    }
+    
+    const user = await ctx.db.get(userId);
+    if (!user || user._id !== room.hostId) {
+      throw new Error("Only the host can update settings");
+    }
+    
+    // Validate settings
+    const newSettings = { ...room.settings };
+    
+    if (args.settings.maxPlayers !== undefined) {
+      if (args.settings.maxPlayers < 2 || args.settings.maxPlayers > 12) {
+        throw new Error("Max players must be between 2 and 12");
+      }
+      newSettings.maxPlayers = args.settings.maxPlayers;
+    }
+    
+    if (args.settings.roundsPerGame !== undefined) {
+      if (args.settings.roundsPerGame < 1 || args.settings.roundsPerGame > 10) {
+        throw new Error("Rounds must be between 1 and 10");
+      }
+      newSettings.roundsPerGame = args.settings.roundsPerGame;
+    }
+    
+    if (args.settings.timePerRound !== undefined) {
+      if (args.settings.timePerRound < 30 || args.settings.timePerRound > 300) {
+        throw new Error("Time per round must be between 30 and 300 seconds");
+      }
+      newSettings.timePerRound = args.settings.timePerRound;
+    }
+    
+    if (args.settings.isPrivate !== undefined) {
+      newSettings.isPrivate = args.settings.isPrivate;
+    }
+    
+    await ctx.db.patch(args.roomId, { settings: newSettings });
+    
+    return null;
+  },
+});
+
+// Get list of public rooms
+export const getPublicRooms = query({
+  args: {},
+  returns: v.array(v.object({
+    _id: v.id("rooms"),
+    code: v.string(),
+    name: v.string(),
+    hostName: v.string(),
+    playerCount: v.float64(),
+    maxPlayers: v.float64(),
+    status: v.string(),
+  })),
+  handler: async (ctx) => {
+    const rooms = await ctx.db
+      .query("rooms")
+      .withIndex("by_status", (q) => q.eq("status", "waiting"))
+      .collect();
+    
+    const publicRooms = rooms.filter(r => !r.settings.isPrivate);
+    
+    const roomsWithInfo = await Promise.all(
+      publicRooms.slice(0, 20).map(async (room) => {
+        const host = await ctx.db.get(room.hostId);
+        const players = await ctx.db
+          .query("players")
+          .withIndex("by_room", (q) => q.eq("roomId", room._id))
+          .filter((q) => q.eq(q.field("status"), "connected"))
+          .collect();
+        
+        return {
+          _id: room._id,
+          code: room.code,
+          name: room.name,
+          hostName: host?.displayName ?? "Unknown",
+          playerCount: players.length,
+          maxPlayers: room.settings.maxPlayers,
+          status: room.status,
+        };
+      })
+    );
+    
+    return roomsWithInfo;
+  },
+});


### PR DESCRIPTION
- Add getRoomState query with complete room information and player data enrichment
- Include isHost and canStart logic calculation
- Filter out kicked players from room state
- Support both authenticated and unauthenticated contexts
- Add supporting mutations: leaveRoom, kickPlayer, updateRoomSettings, getPublicRooms
- Ensure real-time updates via Convex query subscriptions
- Use proper v.float64() validators to match schema