### PR TITLE
Fix type consistency in createRoom settings validation

### DIFF
--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -17,9 +17,9 @@ export const createRoom = mutation({
   args: {
     name: v.string(),
     settings: v.optional(v.object({
-      maxPlayers: v.optional(v.number()),
-      roundsPerGame: v.optional(v.number()),
-      timePerRound: v.optional(v.number()),
+      maxPlayers: v.optional(v.float64()),
+      roundsPerGame: v.optional(v.float64()),
+      timePerRound: v.optional(v.float64()),
       isPrivate: v.optional(v.boolean()),
     })),
   },


### PR DESCRIPTION
- Changed createRoom args from v.number() to v.float64() to match schema
- Ensures type consistency between createRoom, updateRoomSettings, and schema
- All room management mutations (leaveRoom, kickPlayer, updateRoomSettings) verified complete

🤖 Generated with [Claude Code](https://claude.ai/code)