### PR TITLE
Fix room settings dialog rounds validation range

### DIFF
--- a/src/components/room/RoomSettingsDialog.tsx
+++ b/src/components/room/RoomSettingsDialog.tsx
@@ -78,12 +78,12 @@ export function RoomSettingsDialog({
           
           {/* Rounds */}
           <div className="space-y-3">
-            <Label htmlFor="rounds">Total Rounds (1-20)</Label>
+            <Label htmlFor="rounds">Total Rounds (1-10)</Label>
             <Slider
               id="rounds"
               value={[settings.roundsPerGame]}
               min={1}
-              max={20}
+              max={10}
               step={1}
               onValueChange={(value) => setSettings({
                 ...settings,


### PR DESCRIPTION
- Update rounds slider from 1-20 to 1-10 to match issue #10 specification
- Maintain all other validation requirements (Max Players 2-12, Time 30-300s)
- RoomSettingsDialog is fully functional with proper TypeScript types

🤖 Generated with [Claude Code](https://claude.ai/code)