### PR TITLE
fix: resolve ESLint errors in avatar validation PR

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -190,7 +190,7 @@ export const migrateAvatarIds = internalMutation({
   }),
   handler: async (ctx) => {
     let migratedCount = 0;
-    let errorCount = 0;
+    const errorCount = 0;
     
     try {
       // Get all users to check for invalid avatarId values

--- a/src/components/ui/dynamic-icon.tsx
+++ b/src/components/ui/dynamic-icon.tsx
@@ -58,10 +58,10 @@ export const DynamicIcon = forwardRef<SVGSVGElement, DynamicIconProps>(
     if (!IconComponent) {
       return (
         <div 
-          ref={ref as any}
+          ref={ref as React.Ref<HTMLDivElement>}
           className={cn("inline-block", className)} 
           style={{ width: props.size || 16, height: props.size || 16 }}
-          {...(props as any)}
+          {...(props as React.HTMLAttributes<HTMLDivElement>)}
         />
       );
     }

--- a/src/utils/lazy.tsx
+++ b/src/utils/lazy.tsx
@@ -2,7 +2,7 @@ import React, { lazy, ComponentType, ReactElement } from "react";
 import { Loader2 } from "lucide-react";
 
 // Enhanced lazy loading with better error handling and loading states
-export function createLazyComponent<T extends ComponentType<any>>(
+export function createLazyComponent<T extends ComponentType<unknown>>(
   importFunction: () => Promise<{ default: T }>,
   fallback: ReactElement = <div className="flex items-center justify-center p-4">
     <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -45,7 +45,7 @@ export async function loadIcon(iconName: string) {
 }
 
 // Utility to create lazy loaded routes
-export function createLazyRoute<T extends ComponentType<any>>(
+export function createLazyRoute<T extends ComponentType<unknown>>(
   importFunction: () => Promise<{ default: T }>,
   routeName: string = "page"
 ) {


### PR DESCRIPTION
- Change 'let errorCount' to 'const errorCount' in users.ts (was never reassigned)
- Replace 'any' types with proper TypeScript types in dynamic-icon.tsx
- Replace 'ComponentType<any>' with 'ComponentType<unknown>' in lazy.tsx