### PR TITLE
feat: integrate FAL AI SDK for image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@capacitor/haptics": "^7.0.2",
     "@capacitor/ios": "^7.4.2",
     "@convex-dev/auth": "^0.0.88",
+    "@fal-ai/client": "^1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
Integrates FAL AI SDK and configures Flux model for AI image generation to replace placeholder images in the game.

## Changes
- Add @fal-ai/client dependency
- Add 'use node' directive to convex/game.ts
- Configure FAL AI client with environment variable
- Replace generatePlaceholderImages with generateAIImages action
- Implement parallel AI image generation with error handling
- Add random style selection and metadata storage

## Environment Setup Required
```bash
npx convex env set FAL_API_KEY "your-api-key-here"
npx convex env set FAL_ENABLE_SAFETY_CHECKER true
```

Closes #22

Generated with [Claude Code](https://claude.ai/code)